### PR TITLE
Add style for the `/talktoyourself` indicator

### DIFF
--- a/roll20darkcobalt.user.css
+++ b/roll20darkcobalt.user.css
@@ -4013,6 +4013,11 @@
         line-height: 32px;
     }
 
+    #textchat-notifier {
+        background-color: var(--color-bg-light);
+        color: var(--color-yellow);
+    }
+
     #rightsidebar #textchat {
         height: calc(100% - 145px) !important;
     }


### PR DESCRIPTION
When using the command `/talktoyourself on`, an indicator appears above the chat input textbox.  This was showing as white on white, and was impossible to read. I've made some guesses as to reasonable styling to fix this, giving it the same
background color as the area around the text input box, and changing the text to yellow (because it should be fairly obvious when it's turned on).

Everything in here is just meant as a suggestion, of course.  Thanks for making Roll20 bearable to look at!