### PR TITLE
Fix background for zoom panel of floating toolbar

### DIFF
--- a/roll20darkcobalt.user.css
+++ b/roll20darkcobalt.user.css
@@ -2666,7 +2666,7 @@
 
 	*/
     /* ------------------------------ Flotating Bar ----------------------------- */
-    #floatingtoolbar, #floatingtoolbar div.submenu ul, #editinglayer li.gm_slider_box, #secondary-toolbar, #color_selector, #page-toolbar .pages .availablepage .page-actions {
+    #floatingtoolbar, #floatingtoolbar div.submenu ul, #floatingtoolbar div.submenu ul.selZoom, #editinglayer li.gm_slider_box, #secondary-toolbar, #color_selector, #page-toolbar .pages .availablepage .page-actions {
         background-color: var(--color-floating-bar-bg);
         box-shadow: 0px 0px 3px var(--color-text-disabled);
         border-radius: 5px;


### PR DESCRIPTION
The background for the list of zoom options from the floating toolbar was white.  This change applies the same settings to it that are used for the other floating toolbar submenus.

I think I've inserted the new code in the best spot, but I'm not an expert on CSS, so please correct it if something's wrong.  Only tested on Chrome.